### PR TITLE
Do not log 404 client errors

### DIFF
--- a/jax-rs-error-handling-builder/pom.xml
+++ b/jax-rs-error-handling-builder/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.Financial-Times</groupId>
         <artifactId>jax-rs-error-handling</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jax-rs-error-handling-builder/src/main/java/com/ft/api/jaxrs/errors/ClientError.java
+++ b/jax-rs-error-handling-builder/src/main/java/com/ft/api/jaxrs/errors/ClientError.java
@@ -4,6 +4,8 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.core.Response;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -40,7 +42,9 @@ public class ClientError {
         @Override
         public WebApplicationClientException exception(Throwable cause) {
             checkNotNull(cause, "optional argument \"cause\" was unexpectedly null."); // surely null is impossible in a catch block!
-            logLevel.logTo(LOGGER,String.format("message=\"%s\" status=\"%d\"",getMessage(), getStatusCode()), cause);
+            if (getStatusCode() != Response.Status.NOT_FOUND.getStatusCode()) {
+                logLevel.logTo(LOGGER, String.format("message=\"%s\" status=\"%d\"", getMessage(), getStatusCode()), cause);
+            }
             return new WebApplicationClientException(cause, response());
         }
 

--- a/jax-rs-error-handling-model/pom.xml
+++ b/jax-rs-error-handling-model/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.Financial-Times</groupId>
         <artifactId>jax-rs-error-handling</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <packaging>pom</packaging>
     <groupId>com.github.Financial-Times</groupId>
     <artifactId>jax-rs-error-handling</artifactId>
-    <version>2.0.6</version>
+    <version>2.0.7</version>
     <modules>
         <module>jax-rs-error-handling-model</module>
         <module>jax-rs-error-handling-builder</module>


### PR DESCRIPTION
Before:
```
INFO  [2017-06-30 07:32:06,001] com.ft.contentpublicread.service.rest.RestContentReadService: transaction_id=tid_vmsuhrlse0 Calling Content Read RESTful API: http://localhost:8080/content/d348e558-5c01-11e7-9d23-9e9e812637cb document-store-api [dw-34 - GET /content/d348e558-5c01-11e7-9d23-9e9e812637cb]
ERROR [2017-06-30 07:37:28,043] com.ft.api.jaxrs.errors.ClientError$ClientErrorBuilder: transaction_id=tid_vmsuhrlse0 message="Requested item does not exist" status="404" [dw-34 - GET /content/d348e558-5c01-11e7-9d23-9e9e812637cb]
! com.ft.contentpublicread.exception.ContentNotFoundException: Not Found
! at com.ft.contentpublicread.service.rest.RestContentReadService.handleErrorStatus(RestContentReadService.java:131) ~[classes/:na]
! at com.ft.contentpublicread.service.rest.RestContentReadService.getContentByUuid(RestContentReadService.java:67) ~[classes/:na]
! at com.ft.contentpublicread.resources.ContentPublicReadResource.getContentByUuidFromContentReadService(ContentPublicReadResource.java:122) [classes/:na]
! at com.ft.contentpublicread.resources.ContentPublicReadResource.getContentReadByUuid(ContentPublicReadResource.java:108) [classes/:na]
! at com.ft.contentpublicread.resources.ContentPublicReadResource.getContentByUuid(ContentPublicReadResource.java:66) [classes/:na]
! at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_91]
! at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_91]
! at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_91]
! at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_91]
! at com.sun.jersey.spi.container.JavaMethodInvokerFactory$1.invoke(JavaMethodInvokerFactory.java:60) [jersey-server-1.18.1.jar:1.18.1]
! at com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider$TypeOutInvoker._dispatch(AbstractResourceMethodDispatchProvider.java:185) [jersey-server-1.18.1.jar:1.18.1]
! at com.sun.jersey.server.impl.model.method.dispatch.ResourceJavaMethodDispatcher.dispatch(ResourceJavaMethodDispatcher.java:75) [jersey-server-1.18.1.jar:1.18.1]
! at com.codahale.metrics.jersey.InstrumentedResourceMethodDispatchProvider$TimedRequestDispatcher.dispatch(InstrumentedResourceMethodDispatchProvider.java:30) [metrics-jersey-3.0.2.jar:3.0.2]
! at io.dropwizard.jersey.guava.OptionalResourceMethodDispatchAdapter$OptionalRequestDispatcher.dispatch(OptionalResourceMethodDispatchAdapter.java:37) [dropwizard-jersey-0.7.1.jar:0.7.1]
! at com.sun.jersey.server.impl.uri.rules.HttpMethodRule.accept(HttpMethodRule.java:302) [jersey-server-1.18.1.jar:1.18.1]
! at com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:147) [jersey-server-1.18.1.jar:1.18.1]
! at com.sun.jersey.server.impl.uri.rules.ResourceObjectRule.accept(ResourceObjectRule.java:100) [jersey-server-1.18.1.jar:1.18.1]
! at com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:147) [jersey-server-1.18.1.jar:1.18.1]
! at com.sun.jersey.server.impl.uri.rules.RootResourceClassesRule.accept(RootResourceClassesRule.java:84) [jersey-server-1.18.1.jar:1.18.1]
! at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1542) [jersey-server-1.18.1.jar:1.18.1]
! at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1473) [jersey-server-1.18.1.jar:1.18.1]
! at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1419) [jersey-server-1.18.1.jar:1.18.1]
! at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1409) [jersey-server-1.18.1.jar:1.18.1]
! at com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:409) [jersey-servlet-1.18.1.jar:1.18.1]
! at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:540) [jersey-servlet-1.18.1.jar:1.18.1]
! at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:715) [jersey-servlet-1.18.1.jar:1.18.1]
! at javax.servlet.http.HttpServlet.service(HttpServlet.java:848) [javax.servlet-3.0.0.v201112011016.jar:na]
! at io.dropwizard.jetty.NonblockingServletHolder.handle(NonblockingServletHolder.java:49) [dropwizard-jetty-0.7.1.jar:0.7.1]
! at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1515) [jetty-servlet-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.servlets.UserAgentFilter.doFilter(UserAgentFilter.java:83) [jetty-servlets-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.servlets.GzipFilter.doFilter(GzipFilter.java:348) [jetty-servlets-9.0.7.v20131107.jar:9.0.7.v20131107]
! at io.dropwizard.jetty.BiDiGzipFilter.doFilter(BiDiGzipFilter.java:127) [dropwizard-jetty-0.7.1.jar:0.7.1]
! at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1486) [jetty-servlet-9.0.7.v20131107.jar:9.0.7.v20131107]
! at io.dropwizard.servlets.ThreadNameFilter.doFilter(ThreadNameFilter.java:29) [dropwizard-servlets-0.7.1.jar:0.7.1]
! at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1486) [jetty-servlet-9.0.7.v20131107.jar:9.0.7.v20131107]
! at io.dropwizard.jersey.filter.AllowedMethodsFilter.handle(AllowedMethodsFilter.java:44) [dropwizard-jersey-0.7.1.jar:0.7.1]
! at io.dropwizard.jersey.filter.AllowedMethodsFilter.doFilter(AllowedMethodsFilter.java:39) [dropwizard-jersey-0.7.1.jar:0.7.1]
! at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1486) [jetty-servlet-9.0.7.v20131107.jar:9.0.7.v20131107]
! at com.ft.contentpublicread.filter.CacheControlFilter.doFilter(CacheControlFilter.java:34) [classes/:na]
! at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1486) [jetty-servlet-9.0.7.v20131107.jar:9.0.7.v20131107]
! at com.ft.api.util.transactionid.TransactionIdFilter.doFilter(TransactionIdFilter.java:34) [jaxrs-transaction-id-handling-1.9.jar:na]
! at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1486) [jetty-servlet-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:519) [jetty-servlet-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1097) [jetty-server-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:448) [jetty-servlet-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1031) [jetty-server-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:136) [jetty-server-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97) [jetty-server-9.0.7.v20131107.jar:9.0.7.v20131107]
! at com.codahale.metrics.jetty9.InstrumentedHandler.handle(InstrumentedHandler.java:175) [metrics-jetty9-3.0.2.jar:3.0.2]
! at io.dropwizard.jetty.RoutingHandler.handle(RoutingHandler.java:51) [dropwizard-jetty-0.7.1.jar:0.7.1]
! at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97) [jetty-server-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.server.handler.RequestLogHandler.handle(RequestLogHandler.java:92) [jetty-server-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97) [jetty-server-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:162) [jetty-server-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97) [jetty-server-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.server.Server.handle(Server.java:446) [jetty-server-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:271) [jetty-server-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:246) [jetty-server-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.io.AbstractConnection$ReadCallback.run(AbstractConnection.java:358) [jetty-io-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:601) [jetty-util-9.0.7.v20131107.jar:9.0.7.v20131107]
! at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:532) [jetty-util-9.0.7.v20131107.jar:9.0.7.v20131107]
! at java.lang.Thread.run(Thread.java:745) [na:1.8.0_91]
0:0:0:0:0:0:0:1 -  -  [30/Jun/2017:07:32:05 +0000] "GET /content/d348e558-5c01-11e7-9d23-9e9e812637cb HTTP/1.1" 404 - "-" "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36" 322110
```
After:
```
INFO  [2017-06-30 10:03:39,703] com.ft.contentpublicread.service.rest.RestContentReadService: transaction_id=tid_87hx4uxccp Calling Content Read RESTful API: http://localhost:8080/content/d348e558-5
c01-11e7-9d23-9e9e812637cf document-store-api [dw-47 - GET /content/d348e558-5c01-11e7-9d23-9e9e812637cf]
0:0:0:0:0:0:0:1 -  -  [30/Jun/2017:10:03:39 +0000] "GET /content/d348e558-5c01-11e7-9d23-9e9e812637cf HTTP/1.1" 404 - "-" "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Ge
cko) Chrome/59.0.3071.115 Safari/537.36" 172

```
